### PR TITLE
asset-manager-64 Detail log file without Web Image attributes details.

### DIFF
--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/FileSequence.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/FileSequence.java
@@ -73,6 +73,10 @@ public class FileSequence extends ImageGroupParents {
                     }
                 }
 
+                // Because we have a "non-set" state
+                if (!IsTestFailed()) {
+                    PassTest();
+                }
             } catch (DirectoryIteratorException die) {
                 sysLogger.error("Directory iteration error", die);
                 FailTest(Outcome.SYS_EXC, die.getCause().getLocalizedMessage());
@@ -80,6 +84,12 @@ public class FileSequence extends ImageGroupParents {
                 sysLogger.error("Number Format error", nfe);
                 FailTest(Outcome.SYS_EXC, nfe.getCause().getLocalizedMessage());
 
+            }
+            catch (NoSuchFileException nsfe)
+            {
+                String badPath = nsfe.getFile();
+                sysLogger.error("No such file {}", badPath);
+                FailTest(LibOutcome.ROOT_NOT_FOUND, badPath);
             }
         }
 

--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/ImageSizeTests.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/ImageSizeTests.java
@@ -65,20 +65,23 @@ public class ImageSizeTests extends PathTestBase {
                 for (Path imagegroup : imageGroupDirs) {
                     TestImages(imagegroup, imageLimit);
                 }
+                if (!IsTestFailed())
+                {
+                    PassTest();
+                }
             } catch (DirectoryIteratorException die) {
                 sysLogger.error("Directory iteration error", die);
+                FailTest(Outcome.SYS_EXC,die.getMessage());
                 throw die;
             }
-            catch (NoSuchFileException nsfie)
+            catch (NoSuchFileException nsfe)
             {
-                sysLogger.error("No such file {}", getPath());
-                FailTest(LibOutcome.ROOT_NOT_FOUND, getPath());
+                String badPath = nsfe.getFile();
+                sysLogger.error("No such file {}", badPath);
+                FailTest(LibOutcome.ROOT_NOT_FOUND, badPath);
             }
 
-            if (!IsTestFailed())
-            {
-                PassTest();
-            }
+
         }
 
         private void TestImages(final Path imageGroup, Long imageLimit) {

--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/NoFilesInRoot.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/NoFilesInRoot.java
@@ -3,11 +3,7 @@ package io.bdrc.am.audit.audittests;
 import io.bdrc.am.audit.iaudit.Outcome;
 import org.slf4j.Logger;
 
-import java.nio.file.DirectoryIteratorException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
 
 /**
  * NoFilesInRoot tests that, for a Standard Submission Structure (
@@ -54,7 +50,14 @@ public class NoFilesInRoot extends PathTestBase  {
                         // return;
                     }
                 }
-            } catch (DirectoryIteratorException die) {
+            }
+            catch (NoSuchFileException nsfe)
+            {
+                String badPath = nsfe.getFile();
+                sysLogger.error("No such file {}", badPath);
+                FailTest(LibOutcome.ROOT_NOT_FOUND, badPath);
+            }
+            catch (DirectoryIteratorException die) {
                 FailTest(Outcome.SYS_EXC, die.getCause().getLocalizedMessage());
             }
 

--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/NoFoldersInImageGroups.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/NoFoldersInImageGroups.java
@@ -63,7 +63,14 @@ public class NoFoldersInImageGroups extends ImageGroupParents {
 
                     }
                 }
-            } catch (DirectoryIteratorException die) {
+            }
+            catch (NoSuchFileException nsfe)
+            {
+                String badPath = nsfe.getFile();
+                sysLogger.error("No such file {}", badPath);
+                FailTest(LibOutcome.ROOT_NOT_FOUND, badPath);
+            }
+            catch (DirectoryIteratorException die) {
                 sysLogger.error("Directory iteration error", die);
                 FailTest(Outcome.SYS_EXC, die.getCause().getLocalizedMessage());
             }
@@ -82,6 +89,7 @@ public class NoFoldersInImageGroups extends ImageGroupParents {
          */
         private void testNoFolders(Path testFolder) throws IOException {
 
+            String testFolderString = testFolder.toString();
             // Creating the filter. Bring in only directories
             DirectoryStream.Filter<Path> filter = entry -> (entry.toFile().isDirectory());
 
@@ -95,13 +103,19 @@ public class NoFoldersInImageGroups extends ImageGroupParents {
 
                     // Fail the test
                     if (!hasDirs) {
-                        FailTest(LibOutcome.DIR_FAILS_DIR_IN_IMAGES_FOLDER, testFolder.toString());
+                        FailTest(LibOutcome.DIR_FAILS_DIR_IN_IMAGES_FOLDER, testFolderString);
                         hasDirs = true;
                     }
-                    FailTest(LibOutcome.DIR_IN_IMAGES_FOLDER, testFolder.toString(), entry.getFileName().toString());
-
+                    FailTest(LibOutcome.DIR_IN_IMAGES_FOLDER, testFolderString, entry.getFileName().toString());
                 }
-            } catch (DirectoryIteratorException die) {
+            }
+            catch (NoSuchFileException nsfe)
+            {
+                String badPath = nsfe.getFile();
+                sysLogger.error("No such file {}", badPath);
+                FailTest(LibOutcome.ROOT_NOT_FOUND, badPath);
+            }
+            catch (DirectoryIteratorException die) {
                 sysLogger.error("Directory iteration error", die);
                 FailTest(Outcome.SYS_EXC, die.getCause().getLocalizedMessage());
             }


### PR DESCRIPTION
This was a problem of a component of the test path not being found. (the
folder "images"). Changed logging to report discrete errors.