### PR TITLE
asset-manager-68 Image Size test does not consider property

### DIFF
--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/ImageGroupParents.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/ImageGroupParents.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Hashtable;
 
+import static io.bdrc.am.audit.audittests.TestArgNames.*;
+
+
 /**
  * ImageGroupParents is a specific path base test where the names of special "imageGroup"
  * folders are passed in
@@ -21,8 +24,8 @@ abstract public class ImageGroupParents extends PathTestBase {
 
     // Extract only the values for these properties. For example, see audit-test-shell.scripts/shell.properties
     private final ArrayList<String> _propertyKeys = new ArrayList<String>() {{
-        add("ArchiveImageGroupParent");
-        add("DerivedImageGroupParent");
+        add(ARC_GROUP_PARENT);
+        add(DERIVED_GROUP_PARENT);
     }};
 
     // region overrides

--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/ImageSizeTests.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/ImageSizeTests.java
@@ -11,6 +11,8 @@ import java.nio.file.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.bdrc.am.audit.audittests.TestArgNames.*;
+
 public class ImageSizeTests extends PathTestBase {
 
 
@@ -48,14 +50,14 @@ public class ImageSizeTests extends PathTestBase {
         @Override
         public void run() throws IOException {
 
-            Long imageLimit = parseFilesize(keywordArgParams.getOrDefault("MaximumImageSize","400K"));
+            Long imageLimit = parseFilesize(keywordArgParams.getOrDefault(MAX_IMAGE_FILE_SIZE,"400K"));
 
             if (IsTestFailed())
             {
                 return;
             }
             // This test only examines derived image image groups
-            Path examineDir = Paths.get(getPath(), keywordArgParams.getOrDefault("DerivedImageGroupParent",""));
+            Path examineDir = Paths.get(getPath(), keywordArgParams.getOrDefault(DERIVED_GROUP_PARENT,""));
 
             // Creating the filter for non-hidden directories
             DirectoryStream.Filter<Path> filter =

--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/TestArgNames.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/TestArgNames.java
@@ -1,0 +1,10 @@
+package io.bdrc.am.audit.audittests;
+
+/**
+ * Constants for test argument names. Change arg names here only.
+ */
+public class TestArgNames {
+    public static final String ARC_GROUP_PARENT = "ArchiveImageGroupParent";
+    public static final String DERIVED_GROUP_PARENT = "DerivedImageGroupParent";
+    public static final String MAX_IMAGE_FILE_SIZE = "MaximumImageFileSize";
+}

--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/TestDictionary.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/TestDictionary.java
@@ -5,6 +5,8 @@ import io.bdrc.am.audit.iaudit.AuditTestConfig;
 import java.util.Arrays;
 import java.util.Hashtable;
 
+import static io.bdrc.am.audit.audittests.TestArgNames.*;
+
 /**
  * Moved from shell, so I can use class objects here, with names
  * placeholder for true dynamic linking:
@@ -29,7 +31,7 @@ public class TestDictionary {
                     // This statement asserts that the caller has to provide values for these
                     // arguments
                     Arrays.asList(
-                            "ArchiveImageGroupParent", "DerivedImageGroupParent"),
+                            ARC_GROUP_PARENT , DERIVED_GROUP_PARENT),
                     "FileSequence", FileSequence.class));
 
             //noinspection ArraysAsListWithZeroOrOneArgument
@@ -39,15 +41,16 @@ public class TestDictionary {
                     NoFilesInRoot.class));
 
             put("NoFoldersInImageGroups", new AuditTestConfig("No folders allowed in Image Group folders",
-                    Arrays.asList("ArchiveImageGroupParent", "DerivedImageGroupParent"),"NoFoldersInImageGroups",
+                    Arrays.asList(   ARC_GROUP_PARENT , DERIVED_GROUP_PARENT),"NoFoldersInImageGroups",
                     NoFoldersInImageGroups.class));
 
             put("WebImageAttributes", new AuditTestConfig("Web Image Attributes",
-                    Arrays.asList("DerivedImageGroupParent"),"WebImageAttributes",
+                    Arrays.asList(DERIVED_GROUP_PARENT),"WebImageAttributes",
                     ImageAttributeTests.class));
 
             put("FileSizeTests", new AuditTestConfig("File Size Test",
-                    Arrays.asList("DerivedImageGroupParent"),"FileSizeTest",ImageSizeTests.class));
+                    Arrays.asList( DERIVED_GROUP_PARENT,MAX_IMAGE_FILE_SIZE),"FileSizeTest",ImageSizeTests
+                                                                                                          .class));
         }
     };
 }

--- a/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/AssembledAuditTests.java
+++ b/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/AssembledAuditTests.java
@@ -18,6 +18,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Hashtable;
 
+import static io.bdrc.am.audit.audittests.TestArgNames.ARC_GROUP_PARENT;
+import static io.bdrc.am.audit.audittests.TestArgNames.DERIVED_GROUP_PARENT;
+
 /**
  * Class for testing with existing data
  * Ignored because only works on a MacOS when /Volumes/Archive is mounted.
@@ -55,8 +58,8 @@ public class AssembledAuditTests {
     public static Collection Directories() {
         Hashtable<String,String> properties = new Hashtable<String,String>() {
             {
-             put("ArchiveImageGroupParent","archive");
-             put("DerivedImageGroupParent","images");
+             put(ARC_GROUP_PARENT,"archive");
+             put(DERIVED_GROUP_PARENT,"images");
             }
         };
 

--- a/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestFileSequence.java
+++ b/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestFileSequence.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Hashtable;
 
+import static io.bdrc.am.audit.audittests.TestArgNames.ARC_GROUP_PARENT;
+import static io.bdrc.am.audit.audittests.TestArgNames.DERIVED_GROUP_PARENT;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import static org.junit.Assert.*;
@@ -27,8 +29,8 @@ public class TestFileSequence extends AuditTestTestBase{
 
     private final Hashtable<String, String> _emptySequenceTestParams = new Hashtable<>();
     private final Hashtable<String,String> _activeSequenceTestParams = new Hashtable<String,String>() {{
-            put("ArchiveImageGroupParent", "harkeBeepar0lYn");
-            put("DerivedImageGroupParent", "SchmengUndDreck");
+            put(ARC_GROUP_PARENT, "harkeBeepar0lYn");
+            put(DERIVED_GROUP_PARENT, "SchmengUndDreck");
         }};
 
 
@@ -106,7 +108,7 @@ public class TestFileSequence extends AuditTestTestBase{
     @Test
     public void TestFilterOutFiles() {
         Hashtable<String,String> _activeSequenceTestParams = new Hashtable<String,String>() {{
-            put("ArchiveImageGroupParent", "testImages");
+            put(ARC_GROUP_PARENT, "testImages");
             put("IgnoreFileExpressions","*.json,hoopsty");
         }};
         FileSequence st = runTest("src/test/images/WFilterOutJson",_activeSequenceTestParams);

--- a/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestFilteredErrors.java
+++ b/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestFilteredErrors.java
@@ -7,13 +7,15 @@ import org.junit.Test;
 
 import java.util.Hashtable;
 
+import static io.bdrc.am.audit.audittests.TestArgNames.DERIVED_GROUP_PARENT;
+
 public class TestFilteredErrors extends AuditTestTestBase {
 
     private  final Hashtable<String,String> _testParams = new Hashtable<String,String>() {{
         // This value is for published images
-        // put("DerivedImageGroupParent",  "images");
+        // put(DERIVED_GROUP_PARENT,  "images");
         // this tests our collateral
-        put("DerivedImageGroupParent",  "testImages");
+        put(DERIVED_GROUP_PARENT,  "testImages");
     }};
 
 

--- a/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestImageSizeParametersTest.java
+++ b/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestImageSizeParametersTest.java
@@ -17,6 +17,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Hashtable;
 
+import static io.bdrc.am.audit.audittests.TestArgNames.DERIVED_GROUP_PARENT;
+import static io.bdrc.am.audit.audittests.TestArgNames.MAX_IMAGE_FILE_SIZE;
+
 /**
  * Parameterized test
  */
@@ -29,7 +32,7 @@ public class TestImageSizeParametersTest {
     private final Hashtable<String, String> properties;
 //endregion
 
-    private final static String MAX_IMAGE_SIZE_KEY = "MaximumImageSize";
+
 
     public TestImageSizeParametersTest(String pTestSizeExpression, Boolean pShouldTestPass) {
         testSizeExpression = pTestSizeExpression;
@@ -39,8 +42,8 @@ public class TestImageSizeParametersTest {
         properties = new Hashtable<String, String>() {
             {
                 // this is invariant, because it's not the variable under test
-                put("DerivedImageGroupParent", "testImages");
-                put(MAX_IMAGE_SIZE_KEY, pTestSizeExpression);
+                put(DERIVED_GROUP_PARENT, "testImages");
+                put(MAX_IMAGE_FILE_SIZE, pTestSizeExpression);
             }
         };
     }
@@ -139,7 +142,7 @@ public class TestImageSizeParametersTest {
 
         if (expectedToPass)
         {
-            Assert.assertTrue(String.format("Size test parameter %s unexpected result:", properties.get(MAX_IMAGE_SIZE_KEY))
+            Assert.assertTrue(String.format("Size test parameter %s unexpected result:", properties.get(MAX_IMAGE_FILE_SIZE))
                     , (tr.getOutcome().equals(Outcome.PASS))
                               || (tr.getOutcome().equals(Outcome.FAIL)) && !(errors
                                                                                      .get(0)
@@ -153,7 +156,7 @@ public class TestImageSizeParametersTest {
             // only to parse: not fail the size test
 
             Assert.assertTrue(String.format("Size test parameter %s unexpected result:", properties.get
-                                                                                                            (MAX_IMAGE_SIZE_KEY))
+                                                                                                            (MAX_IMAGE_FILE_SIZE))
                     ,
                     (tr.getOutcome().equals(Outcome.FAIL)) && (errors.get(0).getOutcome().equals(LibOutcome
                                                                                                          .BAD_FILE_SIZE_ARG)));

--- a/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestImageSizeTest.java
+++ b/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestImageSizeTest.java
@@ -8,6 +8,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.util.Hashtable;
 
+import static io.bdrc.am.audit.audittests.TestArgNames.DERIVED_GROUP_PARENT;
+import static io.bdrc.am.audit.audittests.TestArgNames.MAX_IMAGE_FILE_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -24,10 +26,10 @@ public class TestImageSizeTest extends AuditTestTestBase {
         public void TestNoSize() {
         Hashtable<String,String> _testParams = new Hashtable<String,String>() {{
             // This value is for published images
-            // put("DerivedImageGroupParent",  "images");
+            // put(DERIVED_GROUP_PARENT,  "images");
             // this tests our collateral
-            put("DerivedImageGroupParent",  "testImages");
-            put("MaximumImageSize","nonIntegerShouldFail");
+            put(DERIVED_GROUP_PARENT,  "testImages");
+            put(MAX_IMAGE_FILE_SIZE,"nonIntegerShouldFail");
         }};
 
            ImageSizeTests imageSizeTests = runTest("src/test/images/WCalibrate", _testParams);
@@ -40,10 +42,10 @@ public class TestImageSizeTest extends AuditTestTestBase {
         public void TestNoDir() {
         Hashtable<String,String> _testParams = new Hashtable<String,String>() {{
             // This value is for published images
-            // put("DerivedImageGroupParent",  "images");
+            // put(DERIVED_GROUP_PARENT,  "images");
             // this tests our collateral
-            put("DerivedImageGroupParent",  "testImages");
-            put("MaximumImageSize","42");
+            put(DERIVED_GROUP_PARENT,  "testImages");
+            put(MAX_IMAGE_FILE_SIZE,"42");
         }};
 
            ImageSizeTests imageSizeTests = runTest("/IDontExist", _testParams);
@@ -56,10 +58,10 @@ public class TestImageSizeTest extends AuditTestTestBase {
     public void TestTooBigfail() {
         Hashtable<String,String> _testParams = new Hashtable<String,String>() {{
             // This value is for published images
-            // put("DerivedImageGroupParent",  "images");
+            // put(DERIVED_GROUP_PARENT,  "images");
             // this tests our collateral
-            put("DerivedImageGroupParent",  "testImages");
-            put("MaximumImageSize","200k");
+            put(DERIVED_GROUP_PARENT,  "testImages");
+            put(MAX_IMAGE_FILE_SIZE,"200k");
         }};
         ImageSizeTests imageSizeTests = runTest("src/test/images/WCalibrate", _testParams);
         TestResult tr =  imageSizeTests.getTestResult();
@@ -72,10 +74,10 @@ public class TestImageSizeTest extends AuditTestTestBase {
     public void TestNoProperty() {
         Hashtable<String,String> _testParams = new Hashtable<String,String>() {{
             // This value is for published images
-            // put("DerivedImageGroupParent",  "images");
+            // put(DERIVED_GROUP_PARENT,  "images");
             // this tests our collateral
-            put("DerivedImageGroupParent",  "testImages");
-          //  put("MaximumImageSize","nonIntegerShouldFail");
+            put(DERIVED_GROUP_PARENT,  "testImages");
+          //  put(MAX_IMAGE_FILE_SIZE,"nonIntegerShouldFail");
         }};
         ImageSizeTests imageSizeTests = runTest("src/test/images/WCalibrate", _testParams);
         TestResult tr =  imageSizeTests.getTestResult();

--- a/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestNoFoldersInImageGroups.java
+++ b/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestNoFoldersInImageGroups.java
@@ -3,9 +3,11 @@ package io.bdrc.am.audit;
 
 import io.bdrc.am.audit.audittests.LibOutcome;
 import io.bdrc.am.audit.audittests.NoFoldersInImageGroups;
-import io.bdrc.am.audit.iaudit.message.TestMessage;
 import io.bdrc.am.audit.iaudit.TestResult;
-import org.junit.*;
+import io.bdrc.am.audit.iaudit.message.TestMessage;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -16,6 +18,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Hashtable;
+
+import static io.bdrc.am.audit.audittests.TestArgNames.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -31,8 +35,8 @@ public class TestNoFoldersInImageGroups extends AuditTestTestBase{
 
     private final Hashtable<String, String> _emptySequenceTestParams = new Hashtable<>();
     private final Hashtable<String,String> _igParentsTestParams = new Hashtable<String,String>() {{
-            put("ArchiveImageGroupParent", "harkeBeepar0lYn");
-            put("DerivedImageGroupParent", "SchmengUndDreck");
+            put(ARC_GROUP_PARENT, "harkeBeepar0lYn");
+            put(DERIVED_GROUP_PARENT, "SchmengUndDreck");
         }};
 
 

--- a/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestProcessedImage.java
+++ b/audittool/audit-test-lib/src/test/java/io/bdrc/am/audit/TestProcessedImage.java
@@ -3,6 +3,7 @@ package io.bdrc.am.audit;
 
 
 import io.bdrc.am.audit.audittests.ImageAttributeTests;
+import io.bdrc.am.audit.audittests.TestArgNames;
 import io.bdrc.am.audit.iaudit.TestResult;
 import io.bdrc.am.audit.iaudit.message.TestMessage;
 import org.junit.Assert;
@@ -18,17 +19,17 @@ public class TestProcessedImage extends AuditTestTestBase {
     /**
      * Put image group parents we want to test in here.
      * Possible  choices for keys are:
-     *         "ArchiveImageGroupParent"
-     *         "DerivedImageGroupParent"
+     *         ARC_GROUP_PARENT
+     *         DERIVED_GROUP_PARENT
      *  Since we dont want to test archive images, we dont add it here.
      *  We're declaring here that only folders with the name 'testImages' contain
      *  folders we want to test.
      */
     private  final Hashtable<String,String> _testParams = new Hashtable<String,String>() {{
         // This value is for published images
-        // put("DerivedImageGroupParent",  "images");
+        // put(DERIVED_GROUP_PARENT,  "images");
         // this tests our collateral
-        put("DerivedImageGroupParent",  "testImages");
+        put(TestArgNames.DERIVED_GROUP_PARENT,  "testImages");
     }};
 
     @Rule

--- a/audittool/audit-test-shell/src/main/scripts/shell.properties
+++ b/audittool/audit-test-shell/src/main/scripts/shell.properties
@@ -10,7 +10,7 @@
 #   450K
 #   1M
 
-MaximumFileSize=450K
+MaximumImageFileSize=400K
 #
 # Parent folders of image groups.
 # An image group folder contains only images. It has to pass FileSequence test


### PR DESCRIPTION
Fixes #68
turned the properties from strings to constants, added to test parameters.