### PR TITLE
asset-manager-74 Java  util exception

### DIFF
--- a/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/FileSequence.java
+++ b/audittool/audit-test-lib/src/main/java/io/bdrc/am/audit/audittests/FileSequence.java
@@ -184,11 +184,15 @@ public class FileSequence extends ImageGroupParents {
                 // If filenames contains entries for every number of files, the test passes.
                 // The last element must be the same as the size, or there are files missing
                 Integer lastKey, size;
-                lastKey = filenames.lastKey();
                 size = filenames.size();
-                if (lastKey > size) {
-                    FailTest(LibOutcome.FILE_COUNT, anImageGroup.toString(), lastKey.toString(), size.toString() );
-                    GenerateFileMissingMessages(filenames);
+
+                // No files at all is not a fail
+                if (size > 0) {
+                    lastKey = filenames.lastKey();
+                    if (lastKey > size) {
+                        FailTest(LibOutcome.FILE_COUNT, anImageGroup.toString(), lastKey.toString(), size.toString());
+                        GenerateFileMissingMessages(filenames);
+                    }
                 }
 
             }


### PR DESCRIPTION
Don't fail if the file size test directory is empty Fixes #74