### PR TITLE
Organizing for v1.0 beta

### DIFF
--- a/audittool/BUILDING.md
+++ b/audittool/BUILDING.md
@@ -1,0 +1,64 @@
+# Build and Release
+# Build
+All versions of Audit tool can be built using maven. The relevant hierarchy is 
+
+```
+├── audittool
+│   ├── pom.xml
+│   ├── IAudit
+│   │   ├── pom.xml
+│   ├── audit-test-shell
+│   │   ├── pom.xml
+│   └── test-lib
+│   │   ├── pom.xml
+```
+
+Each submodule references its parent by this node:
+```xml
+    <parent>
+        <artifactId>audit-tool</artifactId>
+        <groupId>io.bdrc.audit</groupId>
+        <version>1.0-beta-1</version>
+    </parent>
+```
+
+Note that the parent version must be hard coded.
+
+In either the parent or the submodules, you can work with the complete Maven phases. Typically, 
+developers would build using the
+
+`mvn clean install` 
+
+command in the auditool directory.
+
+### Building for debugging
+In the IntelliJ environment, you configure the debugger to `mvn compile` before launching.
+This is shown in the resulting config file: `audittool/.run/shell.run.xml`
+(See Intellij Menu --> Run --> Edit Build Configurations --> Application --> Shell) for the UI selections that built
+the `shell.run.xml` file.)
+
+The compile phase also copies resources file from `src/scripts` into the output folder for testing and packaging.
+
+## Packaging
+The work of pulling together an audit-tool distributable is done in the `audit-test-shell` module's `pom.xml`, in 
+the `package` phase. It uses the `maven-assembly-plugin` whose configuration given in
+`audit-test-shell/src/main/assembly/shell-assembly.xml`
+Essentially creates a zip file and a directory that can be copied and manually installed
+anywhere.
+
+This will unpack an upgrade to v0.9, but it will still need v0.9's special shell script and environment
+scaffolding (see Install-0.9.md) 
+
+## Building an installation kit
+Building an installation kit is as simple as using 
+
+```shell
+cd ${audittool local_git_repo_home}
+mvn clean install
+mvn package # optional, if this is the first time you're building on the target platform
+cd ${audittool local_git_repo_home}/audit-test-shell
+jpackage @src/main/script/jpackage_${platform}.conf
+```
+
+where `${platform}` is one of `{debian|win|MacOS}` and matches the system you are running on.
+(`jpackage` only builds executables for the platforms it runs on)

--- a/audittool/IAudit/pom.xml
+++ b/audittool/IAudit/pom.xml
@@ -2,31 +2,30 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <!-- <parent> -->
-    <!--     <artifactId>audit-tool</artifactId> -->
-    <!--     <groupId>io.bdrc.audit</groupId> -->
-    <!--     <version>1.0-alpha</version> -->
-    <!-- </parent> -->
+     <parent>
+         <artifactId>audit-tool</artifactId>
+         <groupId>io.bdrc.audit</groupId>
+         <version>1.0-beta-1</version>
+     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.bdrc.audit</groupId>
     <artifactId>IAudit</artifactId>
-    <version>1.0-alpha</version>
     <name>IAudit</name>
     <packaging>jar</packaging>
-    <build>
-        <plugins>
-            <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.1</version>
-                <configuration>
-                    <source>14</source>
-                    <target>14</target>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <!-- asset-manager-150 - get compiler standard from parent -->
+<!--    <build>-->
+<!--        <plugins>-->
+<!--            <plugin>-->
+<!--            <groupId>org.apache.maven.plugins</groupId>-->
+<!--            <artifactId>maven-compiler-plugin</artifactId>-->
+<!--            <version>3.8.1</version>-->
+<!--                <configuration>-->
+<!--                    <source>14</source>-->
+<!--                    <target>14</target>-->
+<!--                    <verbose>true</verbose>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
+<!--        </plugins>-->
+<!--    </build>-->
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/audittool/IAudit/pom.xml
+++ b/audittool/IAudit/pom.xml
@@ -39,16 +39,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.8.0-beta4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.7</version>

--- a/audittool/audit-test-shell/pom.xml
+++ b/audittool/audit-test-shell/pom.xml
@@ -5,11 +5,16 @@
     <parent>
         <artifactId>audit-tool</artifactId>
         <groupId>io.bdrc.audit</groupId>
-        <version>1.0-alpha</version>
+        <version>1.0-beta-1</version>
     </parent>
+    <properties>
+        <project.version>1.0-beta-1</project.version>
+    </properties>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shell</artifactId>
+    <version>1.0-beta-1</version>
+
     <packaging>jar</packaging>
     <name>audit-test-shell</name>
     <build>
@@ -123,7 +128,7 @@
         <dependency>
             <groupId>io.bdrc.audit</groupId>
             <artifactId>test-lib</artifactId>
-            <version>1.0-alpha</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -132,27 +137,8 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
-        </dependency>
+
         <!--<dependency>-->
         <!--<groupId>io.bdrc.am</groupId>-->
         <!--<artifactId>audit-test-lib</artifactId>-->

--- a/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/ArgParser.java
+++ b/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/ArgParser.java
@@ -53,7 +53,7 @@ class ArgParser {
         options.addOption(Option.builder(infileOptionShort)
                                   .longOpt(infileOptionLong)
                                   .hasArg(true)
-                                  .desc("Input file, one path per line")
+                                  .desc("Input file, one Path to Work per line")
                                   .build());
 
 //         instead of adding to the group, add to mainline options
@@ -116,7 +116,7 @@ class ArgParser {
             // Log home directory must be writable. Create it now, evaluate result
             if (!madeWritableDir(logDirPath)) {
                 printHelp(options);
-                logger.error("User supplied folder {} cannot be created. Using default", ldpStr);
+                logger.error("User supplied path {} cannot be created. Using default", ldpStr);
             } else {
                 _logDirectory = ldpStr;
             }
@@ -206,7 +206,7 @@ class ArgParser {
 
     /**
      * Overload to test without doing anything
-     * @return
+     * @return if we're not actually doing anything
      */
     public Boolean OnlyShowInfo()
     {
@@ -235,11 +235,10 @@ class ArgParser {
 
     private void printHelp(final Options options) {
         HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp("audit-tool [options] { - | Directory,Directory,Directory}\nwhere:\n\t- read " +
-                                    "folders from " +
-                                    "standard input\n\t" +
-                                    "Directory .... is a list of directories separated by whitespace " +
-                                    "\n[options] are:",
+        formatter.printHelp("audit-tool [options] { - | PathToWork PathToWork ..... }\nwhere:\n" +
+                        "\t- read Paths To Works from standard input\n" +
+                        "\tPathToWork ... is a list of directories separated by whitespace\n" +
+                        "[options] are:",
                 options);
     }
 

--- a/audittool/audit-test-shell/src/main/scripts/jpackage-debian.conf
+++ b/audittool/audit-test-shell/src/main/scripts/jpackage-debian.conf
@@ -12,7 +12,7 @@
 # audit-test-shell: mvn clean package
 
 # Part 1 - Application variables. Must be present in all packages
---app-version '1.0-alpha'
+--app-version '1.0-beta-1'
 
 --copyright 'Copyright 2020-2022, Buddhist Digital Resource Center'
 --description 'Validates image data sets against BDRC standards'
@@ -25,8 +25,8 @@
 #
 # Ex.
 #		jpackage @src/main/scripts/macos-jpackage.conf   
---input target/shell-1.0-alpha-Install/shell-1.0-alpha
---main-jar 'shell-1.0-alpha.jar'
+--input target/shell-1.0-beta-Install/shell-1.0-beta
+--main-jar 'shell-1.0-beta.jar'
 --main-class io.bdrc.audit.shell.shell
 # **** To go over to modules:
 # Using as a template:
@@ -46,7 +46,7 @@
 #
 # Part 4  - platform specific options
 # --type deb
---install-dir audit-tool
+--install-dir /opt/audit-tool
 --linux-package-name audit-v1
---linux-app-release 1
+--linux-app-release 1.1
 

--- a/audittool/audit-test-shell/src/main/scripts/jpackage-debian.conf
+++ b/audittool/audit-test-shell/src/main/scripts/jpackage-debian.conf
@@ -25,8 +25,8 @@
 #
 # Ex.
 #		jpackage @src/main/scripts/macos-jpackage.conf   
---input target/shell-1.0-beta-Install/shell-1.0-beta
---main-jar 'shell-1.0-beta.jar'
+--input target/shell-1.0-beta-1-Install/shell-1.0-beta-1
+--main-jar 'shell-1.0-beta-1.jar'
 --main-class io.bdrc.audit.shell.shell
 # **** To go over to modules:
 # Using as a template:
@@ -48,5 +48,5 @@
 # --type deb
 --install-dir /opt/audit-tool
 --linux-package-name audit-v1
---linux-app-release 1.1
+--linux-app-release 2022-04-04
 

--- a/audittool/audit-test-shell/src/main/scripts/jpackage-debian.conf
+++ b/audittool/audit-test-shell/src/main/scripts/jpackage-debian.conf
@@ -46,6 +46,7 @@
 #
 # Part 4  - platform specific options
 # --type deb
+--install-dir audit-tool
 --linux-package-name audit-v1
 --linux-app-release 1
 

--- a/audittool/pom.xml
+++ b/audittool/pom.xml
@@ -97,6 +97,26 @@
         </plugins>
     </build>
     <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.17.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
+        </dependency>
 
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/audittool/pom.xml
+++ b/audittool/pom.xml
@@ -5,11 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.version>1.0-beta-1</project.version>
     </properties>
     <groupId>io.bdrc.audit</groupId>
     <artifactId>audit-tool</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-alpha</version>
+    <version>1.0-beta-1</version>
     <modules>
         <!-- groupId elements of children -->
         <module>IAudit</module>
@@ -45,49 +46,49 @@
                     <target>16</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-artifact</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>${project.artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>IAudit</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>test-lib</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>shell</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>target/output</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-dependency-plugin</artifactId>-->
+<!--                <version>3.2.0</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>copy-artifact</id>-->
+<!--                        <phase>package</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>copy</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <artifactItems>-->
+<!--                                <artifactItem>-->
+<!--                                    <groupId>${project.groupId}</groupId>-->
+<!--                                    <artifactId>${project.artifactId}</artifactId>-->
+<!--                                    <version>${project.version}</version>-->
+<!--                                    <type>${project.packaging}</type>-->
+<!--                                </artifactItem>-->
+<!--                                <artifactItem>-->
+<!--                                    <groupId>${project.groupId}</groupId>-->
+<!--                                    <artifactId>IAudit</artifactId>-->
+<!--                                    <version>${project.version}</version>-->
+<!--                                    <type>${project.packaging}</type>-->
+<!--                                </artifactItem>-->
+<!--                                <artifactItem>-->
+<!--                                    <groupId>${project.groupId}</groupId>-->
+<!--                                    <artifactId>test-lib</artifactId>-->
+<!--                                    <version>${project.version}</version>-->
+<!--                                    <type>${project.packaging}</type>-->
+<!--                                </artifactItem>-->
+<!--                                <artifactItem>-->
+<!--                                    <groupId>${project.groupId}</groupId>-->
+<!--                                    <artifactId>shell</artifactId>-->
+<!--                                    <version>${project.version}</version>-->
+<!--                                    <type>${project.packaging}</type>-->
+<!--                                </artifactItem>-->
+<!--                            </artifactItems>-->
+<!--                            <outputDirectory>target/output</outputDirectory>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
@@ -95,4 +96,7 @@
             </plugin>
         </plugins>
     </build>
+    <dependencies>
+
+    </dependencies>
 </project>

--- a/audittool/test-lib/pom.xml
+++ b/audittool/test-lib/pom.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.version>1.0-beta-1</project.version>
     </properties>
      <parent>
          <artifactId>audit-tool</artifactId>
@@ -53,27 +54,7 @@
 <!--        </plugins>-->
 <!--    </build>-->
     <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
-        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -85,7 +66,6 @@
             <artifactId>commons-imaging</artifactId>
             <version>1.0-alpha2</version>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -107,7 +87,7 @@
         <dependency>
             <groupId>io.bdrc.audit</groupId>
             <artifactId>IAudit</artifactId>
-            <version>1.0-alpha</version>
+            <version>${project.version}</version>
         </dependency>
         <!--<dependency>-->
         <!--<groupId>gov.nih.imagej</groupId>-->

--- a/audittool/test-lib/pom.xml
+++ b/audittool/test-lib/pom.xml
@@ -5,72 +5,54 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <!-- <parent> -->
-    <!--     <artifactId>audit-tool</artifactId> -->
-    <!--     <groupId>io.bdrc.audit</groupId> -->
-    <!--     <version>1.0-alpha</version> -->
-    <!-- </parent> -->
+     <parent>
+         <artifactId>audit-tool</artifactId>
+         <groupId>io.bdrc.audit</groupId>
+         <version>1.0-beta-1</version>
+     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.bdrc.audit</groupId>
 
     <artifactId>test-lib</artifactId>
-    <version>1.0-alpha</version>
     <packaging>jar</packaging>
-    <name>TestLib</name>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>14</source>
-                    <target>14</target>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
+    <name>test-lib</name>
+<!--    <build>-->
+<!--        <plugins>-->
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-compiler-plugin</artifactId>-->
+<!--                <version>3.8.1</version>-->
+<!--                <configuration>-->
+<!--                    <source>14</source>-->
+<!--                    <target>14</target>-->
+<!--                    <verbose>true</verbose>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
 
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+<!--            <plugin>-->
+<!--                <artifactId>maven-assembly-plugin</artifactId>-->
+<!--                <version>3.3.0</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <phase>package</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>single</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--                <configuration>-->
+<!--                    <archive>-->
+<!--                        <manifest>-->
+<!--                            <addClasspath>true</addClasspath>-->
+<!--                        </manifest>-->
+<!--                    </archive>-->
+<!--                    <descriptorRefs>-->
+<!--                        <descriptorRef>jar-with-dependencies</descriptorRef>-->
+<!--                    </descriptorRefs>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
+<!--        </plugins>-->
+<!--    </build>-->
     <dependencies>
-        <!-- jimk 19-I-22: try to get around org.slf4j not found
-   Remove these -->
-        <!--        <dependency>-->
-
-        <!--            <groupId>org.slf4j</groupId>-->
-        <!--            <artifactId>slf4j-api</artifactId>-->
-        <!--            <version>1.8.0-beta4</version>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.apache.logging.log4j</groupId>-->
-        <!--            <artifactId>log4j-slf4j18-impl</artifactId>-->
-        <!--            <version>2.17.0</version>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
-
-        <!-- replace with these -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
Fixes #150 
Fixes #151 
- Set up more sold parent-child Maven relationship. 
- Change buld output and `jpackage` distribution to v1.0-beta-1 (mac and Windows will follow when there's sufficient content)
- support -v/--version and -h/--help
- Adds support for reading logging levels when debugging (see `audit-test-shell/.idea/shell.run.xml`)
- Fleshes out the building and packaging documentation.

I've asked AO to review this mostly for the BUILDING-1.0.md file, which provides a little more detail into the process. Don't worry about the `pom.xml` config files and etc. No hurry, in a week, or so. I'll be working on other improvements in this branch