### PR TITLE
Support override of sequence length

### DIFF
--- a/audittool/IAudit/src/main/java/io/bdrc/audit/iaudit/PropertyManager.java
+++ b/audittool/IAudit/src/main/java/io/bdrc/audit/iaudit/PropertyManager.java
@@ -92,12 +92,13 @@ public class PropertyManager {
      */
     public PropertyManager MergeConfigGivenInProperty(Path configPath) {
 
+        InputStream ins = null;
         try {
-            LoadProperties(InputFileResource(configPath.toString()));
+           ins = InputFileResource(configPath.toString());
         } catch (IOException e) {
-            logger.warn(String.format("Couldn't open %s ", configPath.toString()), e);
+            logger.warn(String.format("Couldn't open %s ", configPath), e);
         }
-        return this;
+        return LoadProperties(ins);
     }
 
     /**
@@ -269,8 +270,8 @@ public class PropertyManager {
 
     /**
      * get a property's value and map it to a real file path
-     * @param key
-     * @return
+     * @param key property identifier
+     * @return absolute path, relative to "user.dir", of the key's value
      */
     public Path getPropertyPath(String key) {
         String val = getPropertyString(key);
@@ -298,6 +299,18 @@ public class PropertyManager {
      */
     public static PropertyManager PropertyManagerBuilder() {
         _instance = new PropertyManager();
+        return _instance;
+    }
+
+    /**
+     * Use the existing property manager instance or die
+     * @return existing properties manager
+     * @throws IllegalStateException if invoked before constructed
+     */
+    public static PropertyManager getInstance() throws IllegalStateException {
+        if (_instance == null) {
+            throw new IllegalStateException("Property Manager invoked before construction. Contact BDRC support");
+        }
         return _instance;
     }
 

--- a/audittool/test-lib/src/main/java/io/bdrc/audit/audittests/FileSequence.java
+++ b/audittool/test-lib/src/main/java/io/bdrc/audit/audittests/FileSequence.java
@@ -36,14 +36,12 @@ public class FileSequence extends ImageGroupParents {
 
     /**
      * Constructor for variant test name
-     * @param logger
-     * @param testName
+     * @param logger log4j logger for this class
+     * @param testName key of test in database
      */
     public FileSequence(Logger logger, String testName) {
         super(testName);
         sysLogger = logger;
-        _sequenceLength = getSequenceSubstringLength();
-
     }
 
 
@@ -143,7 +141,7 @@ public class FileSequence extends ImageGroupParents {
                 if (failFile(imageGroupParent, anImageGroup)) {
                     continue;
                 }
-                sysLogger.debug("ImageGroup {}", anImageGroup.toString());
+                sysLogger.debug("ImageGroup {}", anImageGroup);
 
                 TreeMap<Integer, String> filenames = new TreeMap<>();
 
@@ -154,6 +152,7 @@ public class FileSequence extends ImageGroupParents {
                     // BUG: Dont parse by sequence length. Requirements call for parsing backward from last .
                     // to first non int, up to field length.
                     String fileSequence = trailingDigits(thisFileName,sequenceLength);
+                    sysLogger.debug(fileSequence);
 
                     int thisFileIndex = 0;
                     try {
@@ -221,6 +220,7 @@ public class FileSequence extends ImageGroupParents {
         private void GenerateFileMissingMessages(final TreeMap<Integer, String> filenames) {
             Integer curEntry = 0;
             for (Map.Entry<Integer, String> entry : filenames.entrySet()) {
+
                 Integer k = entry.getKey();
                 while (++curEntry < k) {
                     FailTest(LibOutcome.FILE_SEQUENCE, String.format("File Sequence %4d missing", curEntry));
@@ -250,13 +250,10 @@ public class FileSequence extends ImageGroupParents {
      */
     private int getSequenceSubstringLength() {
         if (_sequenceLength == 0) {
-            _sequenceLength = PropertyManager.PropertyManagerBuilder().MergeClassResource("/auditTool.properties",
-                    getClass()).getPropertyInt(this.getClass().getSimpleName() + ".SequenceLength");
+            _sequenceLength = PropertyManager.getInstance().getPropertyInt(this.getClass().getSimpleName() + ".SequenceLength");
         }
         return _sequenceLength;
     }
-
-
 
     //endregion
     // region fields


### PR DESCRIPTION
Fixes #122 which called out a suspect line of code.
The line of code used a io.bdrc.audit.PropertyManager method to create a new property manager instance. This new property manager instance contained only the default properties that were embedded in the program, and no configuration entries from either `shell.properties` or `user.properties` . 

This change calls a new `PropertyManager` method to return the current instance (or throw) and not create a new instance.
