### PR TITLE
Shrink long missing sequence reports

### DIFF
--- a/audittool/IAudit/src/main/java/io/bdrc/audit/iaudit/PropertyManager.java
+++ b/audittool/IAudit/src/main/java/io/bdrc/audit/iaudit/PropertyManager.java
@@ -26,7 +26,7 @@ public class PropertyManager {
     private final String UserConfigPathKey = "UserConfigPath";
 
     // as in the config file, this is relative to user's home directory, if not an absolute path
-    private final String UserConfigPathValue = Paths.get(".config", "bdrc", "auditTool", "config").toString();
+    private final String UserConfigPathValue = Paths.get(".config", "bdrc", "auditTool", "user.properties").toString();
 
     /**
      * Load Properties from a stream
@@ -211,8 +211,9 @@ public class PropertyManager {
     private Properties BuildDefaultProperties() {
         return new Properties() {
             {
-                put("io.bdrc.am.audit.audittests.FileSequence.SequenceLength", "4");
-                put("io.bdrc.am.audit.audittests." + UserConfigPathKey, UserConfigPathValue);
+                // jimk asset-manager-158 - looking at resources, they use the simple, not the fully qualified path name
+                put("FileSequence.SequenceLength", "4");
+                put(UserConfigPathKey, UserConfigPathValue);
             }
         };
     }

--- a/audittool/test-lib/src/main/java/io/bdrc/audit/audittests/FileSequence.java
+++ b/audittool/test-lib/src/main/java/io/bdrc/audit/audittests/FileSequence.java
@@ -36,14 +36,14 @@ public class FileSequence extends ImageGroupParents {
 
     /**
      * Constructor for variant test name
-     * @param logger log4j logger for this class
+     *
+     * @param logger   log4j logger for this class
      * @param testName key of test in database
      */
     public FileSequence(Logger logger, String testName) {
         super(testName);
         sysLogger = logger;
     }
-
 
 
     /**
@@ -62,9 +62,9 @@ public class FileSequence extends ImageGroupParents {
 
             // Create directory filter
             DirectoryStream.Filter<Path> dirFilter =
-                    entry ->        !entry.toFile().isHidden()
-                              &&    entry.toFile().isDirectory()
-                              &&    _imageGroupParents.contains(entry.getFileName().toString()) ;
+                    entry -> !entry.toFile().isHidden()
+                            && entry.toFile().isDirectory()
+                            && _imageGroupParents.contains(entry.getFileName().toString());
 
             try (DirectoryStream<Path> pathDirectoryStream = Files.newDirectoryStream(dir, dirFilter)) {
 
@@ -75,7 +75,7 @@ public class FileSequence extends ImageGroupParents {
 
                     // reiterate no files in image group parent test
                     if (!failFile(dir, entry)) {
-                            sequenceImageGroupParent(sequenceLength, entry);
+                        sequenceImageGroupParent(sequenceLength, entry);
                     }
                 }
 
@@ -90,9 +90,7 @@ public class FileSequence extends ImageGroupParents {
                 sysLogger.error("Number Format error", nfe);
                 FailTest(Outcome.SYS_EXC, nfe.getCause().getLocalizedMessage());
 
-            }
-            catch (NoSuchFileException nsfe)
-            {
+            } catch (NoSuchFileException nsfe) {
                 String badPath = nsfe.getFile();
                 sysLogger.error("No such file {}", badPath);
                 FailTest(LibOutcome.ROOT_NOT_FOUND, badPath);
@@ -123,7 +121,7 @@ public class FileSequence extends ImageGroupParents {
          * @param imageGroupParent the directory we're testing
          * @throws IOException on system failures
          */
-        private void sequenceImageGroupParent(final int sequenceLength,  final Path imageGroupParent) throws IOException
+        private void sequenceImageGroupParent(final int sequenceLength, final Path imageGroupParent) throws IOException
         {
             // asset-manager #29 don't count json files in image groups
             DirectoryStream.Filter<Path> dirFilter =
@@ -132,9 +130,9 @@ public class FileSequence extends ImageGroupParents {
             // asset-manager #23 don't count directories in image groups
             // asset-manager #29 don't count json files in image groups
             DirectoryStream.Filter<Path> filesInImageGroupFilter =
-                    entry ->    !entry.toFile().isHidden()
-                            &&  !entry.toFile().isDirectory()
-                            &&  !entry.toString().endsWith("json");
+                    entry -> !entry.toFile().isHidden()
+                            && !entry.toFile().isDirectory()
+                            && !entry.toString().endsWith("json");
 
             for (Path anImageGroup : Files.newDirectoryStream(imageGroupParent, dirFilter)) {
                 boolean firstFolderFailure = false;
@@ -151,7 +149,7 @@ public class FileSequence extends ImageGroupParents {
 
                     // BUG: Dont parse by sequence length. Requirements call for parsing backward from last .
                     // to first non int, up to field length.
-                    String fileSequence = trailingDigits(thisFileName,sequenceLength);
+                    String fileSequence = trailingDigits(thisFileName, sequenceLength);
                     sysLogger.debug(fileSequence);
 
                     int thisFileIndex = 0;
@@ -204,60 +202,66 @@ public class FileSequence extends ImageGroupParents {
         /**
          * Scan a string from the end to the beginning until either 'maxTrailing' digits are found, or a non-digit
          * is found. Returns the String of those digits.
-         * @param source source string
+         *
+         * @param source      source string
          * @param maxTrailing maximum number to look back
          * @return the integer represented by up to the last 'maxTrailing' digits in the string. Stops when a non-digit
          */
         private String trailingDigits(String source, int maxTrailing) {
-            int beginScan = source.length() -1;
+            int beginScan = source.length() - 1;
 
-            while((maxTrailing-- > 0) && (beginScan >= 0) && Character.isDigit(source.charAt(beginScan))) {
+            while ((maxTrailing-- > 0) && (beginScan >= 0) && Character.isDigit(source.charAt(beginScan))) {
                 beginScan--;
             }
 
             return source.substring(++beginScan);
         }
+
         private void GenerateFileMissingMessages(final TreeMap<Integer, String> filenames) {
             Integer curEntry = 0;
             for (Map.Entry<Integer, String> entry : filenames.entrySet()) {
 
+                // jimk asset-manager-158 - one fail report per fail block
+
                 Integer k = entry.getKey();
-                while (++curEntry < k) {
-                    FailTest(LibOutcome.FILE_SEQUENCE, String.format("File Sequence %4d missing", curEntry));
+                if (++curEntry < k) {
+                    FailTest(LibOutcome.FILE_SEQUENCE, String.format("File Sequence %d ... %d missing", curEntry,
+                            k - 1));
+                    curEntry = k;
                 }
             }
         }
     }
 
 
-    @Override
-    public void LaunchTest() {
+        @Override
+        public void LaunchTest() {
 
-        // have base class tests here?
-        // Yes, under the doctrine of One responsibility
-        RunBaseTests();
-        if (IsTestFailed()) {
-            return;
+            // have base class tests here?
+            // Yes, under the doctrine of One responsibility
+            RunBaseTests();
+            if (IsTestFailed()) {
+                return;
+            }
+            TestWrapper(new FileSequenceOperation());
         }
-        TestWrapper(new FileSequenceOperation());
-    }
 
-    /**
-     * Get Sequence length from base class properties
-     *
-     * @return the number of digits at the end of the file name which
-     * represent the sequence
-     */
-    private int getSequenceSubstringLength() {
-        if (_sequenceLength == 0) {
-            _sequenceLength = PropertyManager.getInstance().getPropertyInt(this.getClass().getSimpleName() + ".SequenceLength");
+        /**
+         * Get Sequence length from base class properties
+         *
+         * @return the number of digits at the end of the file name which
+         * represent the sequence
+         */
+        private int getSequenceSubstringLength() {
+            if (_sequenceLength == 0) {
+                _sequenceLength = PropertyManager.getInstance().getPropertyInt(this.getClass().getSimpleName() + ".SequenceLength");
+            }
+            return _sequenceLength;
         }
-        return _sequenceLength;
+
+        //endregion
+        // region fields
+        private int _sequenceLength;
+        // endregion
+
     }
-
-    //endregion
-    // region fields
-    private int _sequenceLength;
-    // endregion
-
-}

--- a/audittool/test-lib/src/test/java/io/bdrc/audit/audittests/AuditTestTestBase.java
+++ b/audittool/test-lib/src/test/java/io/bdrc/audit/audittests/AuditTestTestBase.java
@@ -1,27 +1,48 @@
 package io.bdrc.audit.audittests;
 
 import io.bdrc.audit.iaudit.AuditTestConfig;
+import io.bdrc.audit.iaudit.PropertyManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Hashtable;
 
 class AuditTestTestBase {
 
-     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+
+    protected final PropertyManager propertyManager;
 
     AuditTestTestBase() {
 
+        // jimk asset-manager-158 - discovered that tests need a property manager
+        // See audit-test-shell...shell.java for init sequence.
+
+        propertyManager = PropertyManager.PropertyManagerBuilder();
+
+        try {
+            Path rp = Paths.get("src/test/resources/testResource.properties").toAbsolutePath();
+            if (Files.exists(rp)) {
+                propertyManager.MergeResourceFile(rp.toString());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
 
     /**
      * Loads test dictionary from the resulting jar.
-     * Returns classes which should be runnable
+     * Returns class which should be runnable
      *
      * @param jarUrl       the jar url
      * @param testDictName the test dict name
@@ -38,15 +59,15 @@ class AuditTestTestBase {
 
         Hashtable<String, AuditTestConfig> result = null;
 
-        Class testDict;
+        Class<?> testDict;
         try {
             testDict = Class.forName(testDictName, true, loader);
-            Object instance = testDict.newInstance();
+            Object instance = testDict.getDeclaredConstructor().newInstance();
             Method method = testDict.getDeclaredMethod("getTestDictionary");
 
             result = (Hashtable<String, AuditTestConfig>) method.invoke(instance);
         } catch (InstantiationException | NoSuchMethodException | IllegalAccessException | ClassNotFoundException | InvocationTargetException e) {
-            e.getMessage();
+            logger.error("Get Test Dictionary {}", e.getMessage(), e ) ;
         }
 
         return result;

--- a/audittool/test-lib/src/test/java/io/bdrc/audit/audittests/TestFileSequence.java
+++ b/audittool/test-lib/src/test/java/io/bdrc/audit/audittests/TestFileSequence.java
@@ -1,24 +1,22 @@
 package io.bdrc.audit.audittests;
 
 
-import io.bdrc.audit.audittests.*;
-import io.bdrc.audit.iaudit.*;
-import io.bdrc.audit.audittests.FileSequence;
 import io.bdrc.audit.iaudit.LibOutcome;
 import io.bdrc.audit.iaudit.TestResult;
 import io.bdrc.audit.iaudit.message.TestMessage;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Hashtable;
+import java.util.*;
 
 import static io.bdrc.audit.audittests.TestArgNames.ARC_GROUP_PARENT;
 import static io.bdrc.audit.audittests.TestArgNames.DERIVED_GROUP_PARENT;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import static org.junit.Assert.*;
 
 public class TestFileSequence extends AuditTestTestBase {
@@ -31,53 +29,96 @@ public class TestFileSequence extends AuditTestTestBase {
     private FileSequenceBuilder _IGPfileSequenceBuilder;
 
     private final Hashtable<String, String> _emptySequenceTestParams = new Hashtable<>();
-    private final Hashtable<String,String> _activeSequenceTestParams = new Hashtable<String,String>() {{
-            put(ARC_GROUP_PARENT, "harkaBeepar0lYn");
-            put(DERIVED_GROUP_PARENT, "SchmengUndDreck");
-        }};
+    private final Hashtable<String, String> _activeSequenceTestParams = new Hashtable<>() {{
+        put(ARC_GROUP_PARENT, "harkaBeepar0lYn");
+        put(DERIVED_GROUP_PARENT, "SchmengUndDreck");
+    }};
 
 
     @Before
     public void CreateFileBuilders() {
-       //  _noIGPfileSequenceBuilder = new FileSequenceBuilder(rootFolder);
-        _IGPfileSequenceBuilder = new FileSequenceBuilder(rootFolder,_activeSequenceTestParams.values());
+        //  _noIGPfileSequenceBuilder = new FileSequenceBuilder(rootFolder);
+        _IGPfileSequenceBuilder = new FileSequenceBuilder(rootFolder, _activeSequenceTestParams.values());
     }
 
     @Test
     public void TestPassingFiles() throws IOException {
-        File fileRoot =  _IGPfileSequenceBuilder.BuildPassingFiles();
-        FileSequence fst = runTest(fileRoot.getAbsolutePath(),_activeSequenceTestParams);
+        File fileRoot = _IGPfileSequenceBuilder.BuildPassingFiles();
+        FileSequence fst = runTest(fileRoot.getAbsolutePath(), _activeSequenceTestParams);
 
-        assertTrue("Test did not pass when it should",fst.IsTestPassed());
+        assertTrue("Test did not pass when it should", fst.IsTestPassed());
     }
 
 
     @Test
     /*
-     * An image group folder which has subfolders. It should fail a different test,
-     * but not fail the sequence test. Test that FileSequence disregards subfolders.
+     * An image group folder which has sub folders. It should fail a different test,
+     * but not fail the sequence test. Test that FileSequence disregards sub folders.
      */
     public void TestIGWithSubFolders() throws IOException {
-        File fileRoot =  _IGPfileSequenceBuilder.BuildFileSequencePassingFiles();
-        FileSequence fst = runTest(fileRoot.getAbsolutePath(),_activeSequenceTestParams);
+        File fileRoot = _IGPfileSequenceBuilder.BuildFileSequencePassingFiles();
+        FileSequence fst = runTest(fileRoot.getAbsolutePath(), _activeSequenceTestParams);
 
-        assertTrue("Test did not pass when it should",fst.IsTestPassed());
+        assertTrue("Test did not pass when it should", fst.IsTestPassed());
     }
 
     @Test
     public void TestMissingFiles() throws IOException {
-        File fileRoot = _IGPfileSequenceBuilder.BuildMissingFiles(12,2);
-        FileSequence fst = runTest(fileRoot.getAbsolutePath(),_activeSequenceTestParams);
-        assertTrue("Test did not fail when it should have.",fst.IsTestFailed());
+        File fileRoot = _IGPfileSequenceBuilder.BuildMissingFiles(12, 2);
+        FileSequence fst = runTest(fileRoot.getAbsolutePath(), _activeSequenceTestParams);
+        assertTrue("Test did not fail when it should have.", fst.IsTestFailed());
 
     }
 
     @Test
-    public void TestDuplicateFiles() throws IOException {
-        File fileRoot = _IGPfileSequenceBuilder.BuildMissingFiles(12,1,2);
-        FileSequence fst = runTest(fileRoot.getAbsolutePath(),_activeSequenceTestParams);
+    public void TestMissingFilesWithBigSequence() throws IOException {
 
-        assertTrue("Test passed",fst.IsTestFailed());
+        propertyManager.MergeProperties(new Properties() {
+            {
+                put("FileSequence.SequenceLength", "42");
+            }
+        });
+
+
+        File fileRoot = _IGPfileSequenceBuilder.BuildMissingFiles(24, 3, 1);
+        FileSequence fst = runTest(fileRoot.getAbsolutePath(), _activeSequenceTestParams);
+        TestResult tr = fst.getTestResult();
+        List<String> gapReports =
+                tr.getErrors().stream().map(TestMessage::getMessage).filter(message -> message.contains("...")).toList();
+
+        assertTrue("Test did not fail when it should have.", fst.IsTestFailed());
+
+        // Now check the details
+
+        //Should be a number of duplicate sequences, and some gaps
+        assertEquals(64, gapReports.size());
+
+        HashSet<String> uniqueFails = new HashSet<>(gapReports);
+
+        // The FileSequenceBuilder created (24/4) = 6  groups of every third file, so only
+        // files ending in 3,6,9,12,15,18 were created. That means the gaps
+        // should only have these sequences in them
+        List<String> leftOvers = uniqueFails.stream().filter(x ->
+                !(
+                        x.contains("1 ... 2")
+                                || x.contains("4 ... 5")
+                                || x.contains("7 ... 8")
+                                || x.contains("10 ... 11")
+                                || x.contains("13 ... 14")
+                                || x.contains("16 ... 17")
+                                || x.contains("19 ... 20")
+                                || x.contains("22 ... 23")
+                )
+        ).toList();
+        assertEquals(0, leftOvers.size());
+    }
+
+    @Test
+    public void TestDuplicateFiles() throws IOException {
+        File fileRoot = _IGPfileSequenceBuilder.BuildMissingFiles(12, 1, 2);
+        FileSequence fst = runTest(fileRoot.getAbsolutePath(), _activeSequenceTestParams);
+
+        assertTrue("Test passed", fst.IsTestFailed());
         TestResult tr = fst.getTestResult();
         ArrayList<TestMessage> errors = tr.getErrors();
 
@@ -86,26 +127,26 @@ public class TestFileSequence extends AuditTestTestBase {
         // .getImageGroupsPerParent()
         // One for each duplicate file in each folder, which should be 12 (the first Fill parameter), plus one for each
         // folder which contains the errors ( 12 + 1 = 13)
-        int nExpected = ( _activeSequenceTestParams.size() )* _IGPfileSequenceBuilder.imageGroupsPerParent() * 13   ;
+        int nExpected = (_activeSequenceTestParams.size()) * _IGPfileSequenceBuilder.imageGroupsPerParent() * 13;
 
         Assert.assertEquals(nExpected, errors.size());
 
-        Assert.assertEquals (LibOutcome.DIR_FAILS_SEQUENCE, errors.get(0).getOutcome()) ;
+        Assert.assertEquals(LibOutcome.DIR_FAILS_SEQUENCE, errors.get(0).getOutcome());
 
-        String errorText = errors.get(0).getMessage() ;
-        assertFalse("Should have a message",isEmpty(errorText));
+        String errorText = errors.get(0).getMessage();
+        assertFalse("Should have a message", isEmpty(errorText));
     }
 
     @Test
     public void TestNotExist() {
 
-        FileSequence st = runTest("/MrMxyzptlk",_activeSequenceTestParams);
+        FileSequence st = runTest("/MrMxyzptlk", _activeSequenceTestParams);
         assertTrue(st.IsTestFailed());
         TestResult tr = st.getTestResult();
         ArrayList<TestMessage> errors = tr.getErrors();
 
         assertEquals(1, errors.size());
-        assertEquals(LibOutcome.ROOT_NOT_FOUND, errors.get(0).getOutcome())  ;
+        assertEquals(LibOutcome.ROOT_NOT_FOUND, errors.get(0).getOutcome());
     }
 
     /**
@@ -114,10 +155,10 @@ public class TestFileSequence extends AuditTestTestBase {
     @Test
     public void TestFilterOutFiles() {
 
-        Hashtable<String,String> _activeSequenceTestParams = new Hashtable<String,String>() {{
+        Hashtable<String, String> _activeSequenceTestParams = new Hashtable<>() {{
             put(ARC_GROUP_PARENT, "testImages");
         }};
-        FileSequence st = runTest("src/test/images/WFilterOutJson",_activeSequenceTestParams);
+        FileSequence st = runTest("src/test/images/WFilterOutJson", _activeSequenceTestParams);
         assertTrue(st.IsTestPassed());
     }
 
@@ -129,10 +170,10 @@ public class TestFileSequence extends AuditTestTestBase {
     public void TestIgnoreUnusedKey() {
 
         // Test ignoring an unused key
-        Hashtable<String,String> _activeSequenceTestParams = new Hashtable<String,String>() {{
-            put("IgnoreFileExpressions","*.json,hoopsty");
+        Hashtable<String, String> _activeSequenceTestParams = new Hashtable<>() {{
+            put("IgnoreFileExpressions", "*.json,hoopsty");
         }};
-        FileSequence st = runTest("src/test/images/WFilterOutJson",_activeSequenceTestParams);
+        FileSequence st = runTest("src/test/images/WFilterOutJson", _activeSequenceTestParams);
         assertTrue(st.IsTestPassed());
     }
 
@@ -141,11 +182,12 @@ public class TestFileSequence extends AuditTestTestBase {
      */
     @Test
     public void TestMissingParents() {
-        Hashtable<String,String> _activeSequenceTestParams = new Hashtable<String,String>() {
+        Hashtable<String, String> _activeSequenceTestParams = new Hashtable<>() {
             {
                 put(ARC_GROUP_PARENT, "NonexistentFolder");
-            }};
-        FileSequence st = runTest("src/test/images/WFilterOutJson",_activeSequenceTestParams);
+            }
+        };
+        FileSequence st = runTest("src/test/images/WFilterOutJson", _activeSequenceTestParams);
         assertTrue(st.IsTestPassed());
 
     }
@@ -155,11 +197,11 @@ public class TestFileSequence extends AuditTestTestBase {
     public void setPath() {
         final String whanThatAprille = "WhanThatAprille";
         FileSequence st = new FileSequence();
-        st.setParams(whanThatAprille,_emptySequenceTestParams);
-        assertEquals(st.getPath(),whanThatAprille);
+        st.setParams(whanThatAprille, _emptySequenceTestParams);
+        assertEquals(st.getPath(), whanThatAprille);
     }
 
-    private FileSequence runTest(String path,Hashtable<String,String> igParents ) {
+    private FileSequence runTest(String path, Hashtable<String, String> igParents) {
         FileSequence st = new FileSequence();
         st.setParams(path, igParents);
         st.LaunchTest();


### PR DESCRIPTION
Fixes #158
Have FileSequence test create only one testResult entry for each block of missing files, not one for each file.