### PR TITLE
Put all logs under the --log_dir directory

### DIFF
--- a/audittool/IAudit/src/main/java/io/bdrc/audit/iaudit/PropertyManager.java
+++ b/audittool/IAudit/src/main/java/io/bdrc/audit/iaudit/PropertyManager.java
@@ -47,7 +47,7 @@ public class PropertyManager {
         if (resourceStream == null) return _instance;
         try {
 
-            // We need this input stream twice, so vopy into buffer:
+            // We need this input stream twice, so copy into buffer:
             // byte[] resourceBuffer = IOUtils.toByteArray(resourceStream);
 //            String resourceBuffer = Arrays.toString(IOUtils.toByteArray(resourceStream));
             _Properties.load(resourceStream);

--- a/audittool/audit-test-shell/src/main/java/io/bdrc/audit/log/AuditLogController.java
+++ b/audittool/audit-test-shell/src/main/java/io/bdrc/audit/log/AuditLogController.java
@@ -1,0 +1,36 @@
+package io.bdrc.audit.log;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+
+import java.nio.file.Paths;
+
+/**
+ * Set up all logs
+ */
+
+public class AuditLogController {
+    // rewrite of AuditLogController0, using
+    // the strategy of setting a system property before loading the log4j 2 configuration
+    // https://newbedev.com/log4j2-assigning-file-appender-filename-at-runtime
+
+
+    // WARNING:  MUST MATCH VALUE IN LOG4J2.PROPERTIES
+    private static final String AT_LOGDIR_PROP_NAME = "AUDIT_LOG_ROOT" ;
+
+    // Fallback if log dir is not set
+    private static final String AT_LOGDIR_DEFAULT_PROP = "user.home" ;
+    private static final String AT_LOGDIR_DEFAULT = "audit-test-logs";
+
+    public static void setLogDirectory( String logDirectory) {
+
+        String defaultLogDir = Paths.get(System.getProperty(AT_LOGDIR_DEFAULT_PROP),AT_LOGDIR_DEFAULT ).toString();
+        logDirectory = StringUtils.isEmpty(logDirectory) ? defaultLogDir : logDirectory ;
+        System.setProperty(AT_LOGDIR_PROP_NAME, logDirectory);
+
+        // and reconfigure the logger:
+        org.apache.logging.log4j.core.LoggerContext ctx = (org.apache.logging.log4j.core.LoggerContext)
+                LogManager.getContext(false);
+        ctx.reconfigure();
+    }
+}

--- a/audittool/audit-test-shell/src/main/java/io/bdrc/audit/log/AuditTestLogController.java
+++ b/audittool/audit-test-shell/src/main/java/io/bdrc/audit/log/AuditTestLogController.java
@@ -1,4 +1,4 @@
-package io.bdrc.audit.shell;
+package io.bdrc.audit.log;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.io.FilenameUtils;
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Creates a new appender for a specific work result. Not involved with either the summary, detail, or shell loggers
  */
-class AuditTestLogController {
+public class AuditTestLogController {
 
     private static final String EACHWORKAPPENDER = "PerWorkAppender";
     private static String DEFAULTLOGDIR;
@@ -141,7 +141,7 @@ class AuditTestLogController {
     // endregion
 
     //region public methods
-    void ChangeAppender(final String appenderFileName) {
+    public void ChangeAppender(final String appenderFileName) {
 
         Map<String, Appender> existingAppenders = _testResultLogger.getAppenders();
         Appender curAppender;
@@ -188,17 +188,17 @@ class AuditTestLogController {
     /**
      * Rename the log file to indicate test passed
      */
-    void RenameLogPass() throws IOException {
+    public void RenameLogPass() throws IOException {
         RenameFile("passPrefix");
 
     }
 
-    void RenameLogFail() throws IOException
+    public void RenameLogFail() throws IOException
     {
         RenameFile("failPrefix");
     }
 
-    void RenameLogWarn() throws IOException
+    public void RenameLogWarn() throws IOException
     {
         RenameFile("warnPrefix");
     }

--- a/audittool/audit-test-shell/src/main/java/io/bdrc/audit/log/CoreLogger.java
+++ b/audittool/audit-test-shell/src/main/java/io/bdrc/audit/log/CoreLogger.java
@@ -1,0 +1,16 @@
+package io.bdrc.audit.log;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+
+/**
+ * Container for logging utilities.
+ */
+public class CoreLogger {
+    public static Logger getCoreLogger(org.slf4j.Logger logger) {
+        if (logger == null) {
+            return null;
+        }
+        return (org.apache.logging.log4j.core.Logger) LogManager.getLogger(logger.getName());
+    }
+}

--- a/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/ArgParser.java
+++ b/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/ArgParser.java
@@ -4,6 +4,7 @@ package io.bdrc.audit.shell;
 
 import io.bdrc.audit.shell.diagnostics.DiagnosticService;
 import org.apache.commons.cli.*;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -163,7 +164,7 @@ class ArgParser {
                     getReadStdIn()
                             || HasOnlyShowInfo()
                             || HasOnlyShowTestNames()
-                        )
+            )
             ) {
                 logger.error("Selected options require one or more PathToWork.");
             }
@@ -365,7 +366,6 @@ class ArgParser {
 
     /**
      * Show diagnostic help
-     *
      */
     private void OnlyShowDiagSyntax() {
         Map<String, String[]> syntax = DiagnosticService.getDiagServiceSyntax();
@@ -420,10 +420,10 @@ class ArgParser {
     private String _logDirectory;
 
     /**
-     * @return Command line value of -l argument
+     * @return Command line value of -l argument, empty string if not given
      */
     String getLogDirectory() {
-        return _logDirectory;
+        return StringUtils.isEmpty(_logDirectory) ? StringUtils.EMPTY : _logDirectory;
     }
 
     /**

--- a/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/diagnostics/DiagnosticService.java
+++ b/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/diagnostics/DiagnosticService.java
@@ -2,6 +2,7 @@ package io.bdrc.audit.shell.diagnostics;
 
 import com.google.common.collect.ImmutableMap;
 import io.bdrc.audit.iaudit.PropertyManager;
+import io.bdrc.audit.log.CoreLogger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.appender.FileAppender;
@@ -161,19 +162,15 @@ public class DiagnosticService {
                 .build();
 
         fileAppender.start();
-        getCoreLogger(_logger).addAppender(fileAppender);
+        CoreLogger.getCoreLogger(_logger).addAppender(fileAppender);
         return fileAppender;
-    }
-
-    private org.apache.logging.log4j.core.Logger getCoreLogger(org.slf4j.Logger logger) {
-        return (org.apache.logging.log4j.core.Logger) LogManager.getLogger(logger.getName());
     }
 
     private void stopLogAppender(Appender appender) {
 
         if (appender == null) return;
         appender.stop();
-        getCoreLogger(_logger).removeAppender(appender);
+        CoreLogger.getCoreLogger(_logger).removeAppender(appender);
 
     }
 }

--- a/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/shell.java
+++ b/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/shell.java
@@ -2,6 +2,8 @@ package io.bdrc.audit.shell;
 
 import io.bdrc.audit.iaudit.*;
 import io.bdrc.audit.iaudit.message.TestMessage;
+import io.bdrc.audit.log.AuditLogController;
+import io.bdrc.audit.log.AuditTestLogController;
 import io.bdrc.audit.shell.diagnostics.DiagnosticService;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -67,10 +69,6 @@ public class shell {
         List<Integer> allResults = new ArrayList<>();
 
 
-        sysLogger = LoggerFactory.getLogger("sys"); // shellLogger.name=shellLogger //("root");
-        detailLogger = LoggerFactory.getLogger("detailLogger"); //("root");
-        testResultLogger = LoggerFactory.getLogger("testResultLogger");
-
         try {
 
             // TODO: Rework sysLogger to respect --log_dir. Means that arg parsing logging goes only to console
@@ -79,10 +77,15 @@ public class shell {
             ArgParser argParser = new ArgParser(args);
 
             if (!argParser.getParsed()) {
-                sysLogger.trace("Invalid arguments");
                 System.out.println("Exiting on Invalid arguments");
                 System.exit(SYS_ERR);
             }
+
+            AuditLogController.setLogDirectory( argParser.getLogDirectory());
+
+            sysLogger = LoggerFactory.getLogger("sys"); // shellLogger.name=shellLogger //("root");
+            detailLogger = LoggerFactory.getLogger("detailLogger"); //("root");
+            testResultLogger = LoggerFactory.getLogger("testResultLogger");
 
             sysLogger.trace("Resolving properties");
             Path resourceFile = resolveResourceFile();

--- a/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/shell.java
+++ b/audittool/audit-test-shell/src/main/java/io/bdrc/audit/shell/shell.java
@@ -70,10 +70,6 @@ public class shell {
 
 
         try {
-
-            // TODO: Rework sysLogger to respect --log_dir. Means that arg parsing logging goes only to console
-            sysLogger.trace("Entering main");
-            sysLogger.trace("Parsing args");
             ArgParser argParser = new ArgParser(args);
 
             if (!argParser.getParsed()) {
@@ -300,7 +296,6 @@ public class shell {
 
             // extract the property values the test needs
             Hashtable<String, String> propertyArgs = ResolveArgNames(testConfig.getArgNames(), shellProperties);
-
 
             results.add(TestOnDirPassed((Class<IAuditTest>) testClass, testLogger, testName, testDesc, propertyArgs,
                     aTestDir));

--- a/audittool/audit-test-shell/src/main/java/module-info.java
+++ b/audittool/audit-test-shell/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module io.bdrc.audit.shell {
     exports io.bdrc.audit.shell;
     exports io.bdrc.audit.shell.diagnostics;
+    exports io.bdrc.audit.log;
     requires io.bdrc.audit.IAudit;
     requires io.bdrc.audit.tests;
     requires org.apache.commons.io;

--- a/audittool/audit-test-shell/src/main/scripts/log4j2.properties
+++ b/audittool/audit-test-shell/src/main/scripts/log4j2.properties
@@ -1,6 +1,7 @@
 status=info
 dest=err
-name=AppLogconfig
+name=AuditLogConfig
+
 
 property.applicationName=AuditTestShell
 property.logFileDir=log
@@ -10,10 +11,12 @@ property.csvFileDir=csv
 # issue #32: https://github.com/buda-base/asset-manager/issues/32
 # Windows users can use:
 # property.logRoot=${sys:user.home}/Documents/audit-test-logs
-property.logRoot=${sys:user.home}/audit-test-logs
 
+# WARNING: Must match key AT_LOGDIR_PROP_NAME in audit-test-shell/io.bdrc.audit.log/AuditLogController.java
 # Unglaubische dummheit https://stackoverflow.com/questions/40565881/log4j2-logs-into-user-home-folder
 # Expected it to be ${user.home}, but no, has to be ${sys:user.home}
+property.logRoot=${sys:AUDIT_LOG_ROOT}
+
 
 property.filename=rollingtest.log
 property.SUM=SUMMARY
@@ -47,7 +50,8 @@ rootLogger.appenderRef.rootShell.ref=console
 rootLogger.appenderRef.rootSummary.ref=summary
 
 logger.shellLogger.name=sys
-# Comment this to use root logger
+# Comment this to use root logger's level. Very useful if you want to debug and keep the debug output
+# You set rootLogger level to info
 logger.shellLogger.level=info
 
 # The shell writes into the console and summary, and detail logs


### PR DESCRIPTION
fixes #171 

Formerly, audit tool would only put the work run logs in the directory given by the -l/--log_dir flag. The detail, summary, and test result logs would still go into ~/audit-test-logs.

With this change, all logs will go under the `-l` directory (the summary and details will still go into subdirectories `log/` and `csv/`)

Note the diagnostic log file is not included in this arrangement. It will be placed exactly where the `-D DiagnosticFileName` places it.